### PR TITLE
29 record text should be preserved when any save error happens

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -9,6 +9,7 @@ import {
   Button,
   Toolbar,
   IconButton,
+  LinearProgress,
 } from '@mui/material'
 import SettingsIcon from '@mui/icons-material/Settings'
 
@@ -16,62 +17,54 @@ const Layout: React.FunctionComponent = () => {
   const navigation = useNavigation()
   const { t } = useTranslation(['layout', 'general'])
 
-  if (navigation.state === 'idle') {
-    return (
-      <Box sx={{ flexGrow: 1 }}>
-        <AppBar position="static">
-          <Toolbar>
-            <Typography
-              to="/"
-              component={RouterLink}
-              variant="h6"
-              color="inherit"
-              sx={{ flexGrow: 1, textDecoration: 'none' }}
-            >
-              Markdairy
-            </Typography>
+  const content = navigation.state === 'idle' ? <Outlet /> : <LinearProgress />
 
-            <Button
-              to="/new"
-              color="inherit"
-              component={RouterLink}
-              sx={{ display: { xs: 'none', sm: 'block' } }}
-            >
-              {t('New record')}
-            </Button>
+  return (
+    <Box sx={{ flexGrow: 1 }}>
+      <AppBar position="static">
+        <Toolbar>
+          <Typography
+            to="/"
+            component={RouterLink}
+            variant="h6"
+            color="inherit"
+            sx={{ flexGrow: 1, textDecoration: 'none' }}
+          >
+            Markdairy
+          </Typography>
 
-            <Button
-              to="/config"
-              color="inherit"
-              component={RouterLink}
-              area-label="Configuration"
-              sx={{ display: { xs: 'none', sm: 'block' } }}
-            >
-              {t('Configuration')}
-            </Button>
-            <IconButton
-              to="/config"
-              component={RouterLink}
-              color="inherit"
-              sx={{ display: { xs: 'block', sm: 'none' } }}
-            >
-              <SettingsIcon />
-            </IconButton>
-          </Toolbar>
-        </AppBar>
+          <Button
+            to="/new"
+            color="inherit"
+            component={RouterLink}
+            sx={{ display: { xs: 'none', sm: 'block' } }}
+          >
+            {t('New record')}
+          </Button>
 
-        <Container maxWidth="md">
-          <Outlet />
-        </Container>
-      </Box>
-    )
-  } else {
-    return (
-      <Box>
-        <p>{t('loading...', { ns: 'general' })}</p>
-      </Box>
-    )
-  }
+          <Button
+            to="/config"
+            color="inherit"
+            component={RouterLink}
+            area-label="Configuration"
+            sx={{ display: { xs: 'none', sm: 'block' } }}
+          >
+            {t('Configuration')}
+          </Button>
+          <IconButton
+            to="/config"
+            component={RouterLink}
+            color="inherit"
+            sx={{ display: { xs: 'block', sm: 'none' } }}
+          >
+            <SettingsIcon />
+          </IconButton>
+        </Toolbar>
+      </AppBar>
+
+      <Container maxWidth="md">{content}</Container>
+    </Box>
+  )
 }
 
 export default Layout

--- a/src/components/record/record-new.tsx
+++ b/src/components/record/record-new.tsx
@@ -1,14 +1,28 @@
-import { Button, Container, Stack, TextField, Typography } from '@mui/material'
+import {
+  Alert,
+  Button,
+  Container,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material'
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Form } from 'react-router-dom'
+import { Form, useActionData } from 'react-router-dom'
+import { SaveRecordProblem } from './record-actions'
 
 const RecordNew: React.FunctionComponent = () => {
-  const [content, setContent] = useState('')
+  const savingProblem = useActionData() as SaveRecordProblem | undefined
+  const [content, setContent] = useState(savingProblem?.recordText || '')
   const { t } = useTranslation(['record', 'general'])
+
+  const errorAlert = savingProblem ? (
+    <Alert severity="error">Saving failed: {savingProblem.error.message}</Alert>
+  ) : null
 
   return (
     <Container>
+      {errorAlert}
       <Typography variant="h4">{t('New Record')}</Typography>
       <Form method="post">
         <Stack>


### PR DESCRIPTION
When record save failed, loader handles an error and stays on a "new record" screen with text preserved